### PR TITLE
Adds example kali linux deployment using ssm

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,5 +2,7 @@
 
 Various examples of how to get things done.
 
-## cloudFormation
+## AWS
 
+- [CloudFormation](aws/cloudformation/)
+  - Deploying Kali Linux as an EC2 using SSM [without SSH](aws/cloudformation/ec2/pentest.yaml)

--- a/aws/cloudformation/ec2/pentest.yaml
+++ b/aws/cloudformation/ec2/pentest.yaml
@@ -1,0 +1,144 @@
+Parameters:
+  ami:
+    Type: AWS::EC2::Image::Id
+    Description: The Kali Linux AMI to use. Remember to subscribe in the marketplace. (Default AMI from us-west-2)
+    Default: ami-0a6335995610caf00
+  subnet:
+    Type: String
+    Description: The subnet to deploy the instance in. (Private is preferred.)
+  group:
+    Type: String
+    Description: The iam group that will be allowed access to the instance.
+  password:
+    Type: String
+    Description: The password for VNC.
+    NoEcho: true
+Resources:
+  kindlyInstanceRole4C88F8DF:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: 'sts:AssumeRole'
+            Effect: Allow
+            Principal:
+              Service: ec2.amazonaws.com
+        Version: 2012-10-17
+      ManagedPolicyArns:
+        - !Join 
+          - ''
+          - - 'arn:'
+            - !Ref 'AWS::Partition'
+            - ':iam::aws:policy/AmazonSSMManagedInstanceCore'
+  kindlyInstanceProfile:
+    Type: 'AWS::IAM::InstanceProfile'
+    Properties:
+      Roles:
+        - !Ref kindlyInstanceRole4C88F8DF
+  kindlyInstance:
+    Type: 'AWS::EC2::Instance'
+    Properties:
+      BlockDeviceMappings:
+        - DeviceName: /dev/sda1
+          Ebs:
+            DeleteOnTermination: true
+            VolumeSize: 40
+      IamInstanceProfile: !Ref kindlyInstanceProfile
+      ImageId: !Ref ami
+      InstanceType: t2.xlarge
+      SubnetId: !Ref subnet
+      Tags:
+        - Key: Name
+          Value: kindlyops-internal-pentest
+      UserData: !Base64 
+        'Fn::Sub': >-
+          #!/bin/bash
+
+          export DEBIAN_FRONTEND=noninteractive
+
+          apt update
+
+          # Install cfn tools
+
+          apt install -y python-pip
+
+          apt install -y python-setuptools
+
+          cd /tmp/ || return
+
+          wget
+          https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz
+
+          pip install aws-cfn-bootstrap-latest.tar.gz
+
+
+          # Install kali goodies
+
+          apt install -y kali-linux-default
+
+          apt install -y offsec-pwk
+
+          apt install -y kali-desktop-xfce
+
+
+          # Install ssm
+
+          mkdir /tmp/ssm
+
+          cd /tmp/ssm || return
+
+          wget
+          https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/debian_amd64/amazon-ssm-agent.deb
+
+          sudo dpkg -i amazon-ssm-agent.deb
+
+          sudo systemctl enable amazon-ssm-agent
+
+          sudo systemctl start amazon-ssm-agent
+
+
+          /usr/local/bin/cfn-signal -e $? --resource kindlyInstance \
+              --stack ${AWS::StackName} \
+              --region ${AWS::Region}
+
+          export HOME=/home/kali/
+
+          export USER=kali
+
+          # Configure vncserver
+
+          mkdir /home/kali/.vnc/
+
+          echo "${password}" | vncpasswd -f >/home/kali/.vnc/passwd
+
+          chmod 0600 /home/kali/.vnc/passwd
+
+          vncserver -geometry 1920x1080
+    CreationPolicy:
+      ResourceSignal:
+        Count: 1
+        Timeout: PT45M
+
+  kindlySSMPolicy:
+    Type: 'AWS::IAM::Policy'
+    Properties:
+      PolicyDocument:
+        Statement:
+          - Sid: ssmStart
+            Effect: Allow
+            Action:
+              - 'ssm:StartSession'
+            Resource:
+              - !Sub >-
+                arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:instance/${kindlyInstance}
+              - !Sub >-
+                arn:aws:ssm:${AWS::Region}:*:document/AWS-StartPortForwardingSession
+          - Sid: ssmTerminate
+            Effect: Allow
+            Action:
+              - 'ssm:TerminateSession'
+            Resource: 'arn:aws:ssm:*:*:session/${aws:username}-*'
+      PolicyName: kindlySSMPolicy
+      Groups:
+        - !Ref group
+


### PR DESCRIPTION
This will deploy a kali linux instance and allow
an IAM group to access it and use ssm port forwarding
for remote desktop and terminal access without ssh.